### PR TITLE
portalocker 3.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ requirements:
     - pip
     - pytest-runner
     - setuptools
-    - setuptoools-scm 
+    - setuptools_scm
+    - wheel
   run:
     - python
     - pywin32 >=226  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   host:
     - python
     - pip
-    - pytest-runner
     - setuptools
     - setuptools_scm
     - wheel
@@ -35,7 +34,7 @@ test:
   requires:
     - pip
     - pytest
-    - redis
+    - redis-py
   commands:
     - pip check
     - pytest -v portalocker_tests --ignore=portalocker_tests/test_combined.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,8 @@ about:
   license_family: PSF
   license_file: LICENSE
   summary: Portalocker is a library to provide an easy API to file locking.
+  description: |
+    An easy library for Python file locking. It works on Windows, Linux, BSD and Unix systems and can even perform distributed locking. Naturally it also supports the with statement.
   doc_url: https://portalocker.readthedocs.org
   dev_url: https://github.com/WoLpH/portalocker
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "portalocker" %}
-{% set version = "2.3.0" %}
+{% set version = "3.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,11 +8,12 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4e913d807aa6598c320e8a50c50e2ee0602bc45240b485e3f8bc06f13060084c
+  sha256: 21f535de2e7a82c94c130c054adb5c7421d480d5619d61073996e2f89bcb879b
 
 build:
   number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<38 or py>312]
 
 requirements:
   host:
@@ -33,7 +34,7 @@ test:
     - pytest-cache >=1.0
     - pytest-cov >=2.5.1
     - pytest-flakes >=2.0.0
-    - pytest-pep8 >=1.0.6
+    #- pytest-pep8 >=1.0.6
   # TODO: how to skip just test_combined ?
   # commands:
   #  - pytest -k "not test_combined" portalocker_tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,33 +11,28 @@ source:
   sha256: 21f535de2e7a82c94c130c054adb5c7421d480d5619d61073996e2f89bcb879b
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [py<38 or py>312]
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
     - python
     - pip
     - pytest-runner
+    - setuptools
+    - setuptoools-scm 
   run:
     - python
-    - pywin32  # [win]
+    - pywin32 >=226  # [win]
 
 test:
   imports:
     - portalocker
-  source_files:
-    - portalocker_tests
   requires:
-    - pytest >=3.4.0
-    - pytest-cache >=1.0
-    - pytest-cov >=2.5.1
-    - pytest-flakes >=2.0.0
-    #- pytest-pep8 >=1.0.6
-  # TODO: how to skip just test_combined ?
-  # commands:
-  #  - pytest -k "not test_combined" portalocker_tests
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/WoLpH/portalocker

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,17 @@ requirements:
     - pywin32 >=226  # [win]
 
 test:
+  source_files:
+    - portalocker_tests
   imports:
     - portalocker
   requires:
     - pip
+    - pytest
+    - redis
   commands:
     - pip check
+    - pytest -v portalocker_tests --ignore=portalocker_tests/test_combined.py
 
 about:
   home: https://github.com/WoLpH/portalocker
@@ -41,7 +46,7 @@ about:
   license_family: PSF
   license_file: LICENSE
   summary: Portalocker is a library to provide an easy API to file locking.
-  doc_url: http://portalocker.readthedocs.org
+  doc_url: https://portalocker.readthedocs.org
   dev_url: https://github.com/WoLpH/portalocker
 
 extra:


### PR DESCRIPTION
portalocker 3.0.0

**Destination channel:** defaults

### Links

- [PKG-6510](https://anaconda.atlassian.net/browse/PKG-6510) 
- [Upstream repository](https://github.com/WoLpH/portalocker/tree/v3.0.0  )
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/torchdata-feedstock/pull/4

### Explanation of changes:

- building 3.0.0 - for `torchdata`
- added back in tests


[PKG-6510]: https://anaconda.atlassian.net/browse/PKG-6510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ