### PR TITLE
portalocker 3.2.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "portalocker" %}
-{% set version = "3.0.0" %}
+{% set version = "3.2.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 21f535de2e7a82c94c130c054adb5c7421d480d5619d61073996e2f89bcb879b
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac
 
 build:
   number: 0
@@ -26,18 +25,21 @@ requirements:
     - python
     - pywin32 >=226  # [win]
 
+# Won`t copy README.rst to the sp_dir:
+# E       FileNotFoundError: [Errno 2] No such file or directory: '$PREFIX/lib/python3.10/site-packages/README.rst'
+{% set deselect_tests = " --deselect=portalocker_tests/test_combined.py::test_combined" %}
 test:
   source_files:
     - portalocker_tests
   imports:
     - portalocker
-  requires:
-    - pip
-    - pytest
-    - redis-py
   commands:
     - pip check
-    - pytest -v portalocker_tests --ignore=portalocker_tests/test_combined.py
+    - pytest -v portalocker_tests {{ deselect_tests }}
+  requires:
+    - pip
+    - pytest >=5.4.1
+    - redis-py
 
 about:
   home: https://github.com/WoLpH/portalocker


### PR DESCRIPTION
portalocker 3.2.0 

**Destination channel:** Defaults

### Links

- [PKG-10818]
- dev_url:        https://github.com/WoLpH/portalocker/tree/v3.2.0
- conda_forge:    https://github.com/conda-forge/portalocker-feedstock
- pypi:           https://pypi.org/project/portalocker/3.2.0
- pypi inspector: https://inspector.pypi.io/project/portalocker/3.2.0

### Explanation of changes:

- new version number


[PKG-10818]: https://anaconda.atlassian.net/browse/PKG-10818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ